### PR TITLE
Multi samples

### DIFF
--- a/sim/validator.py
+++ b/sim/validator.py
@@ -150,8 +150,6 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     # Prepare Genomes
     samples = ["sample1", "sample2"]
     
-    simulate_genome(reference_path, simulated_genome_path + 'sample2.')
-
     # Simulate Reads
     for sample in samples:
         simulate_genome(reference_path, simulated_genome_path + sample + '.')
@@ -179,26 +177,6 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     stats_table = pd.DataFrame(stats)
     stats_table.to_csv(results_path + "stats.csv")
 
-def temp():
-    results_path = '/home/aaronfishman/temp-results/simulated-6/'
-    samples = ["sample1", "sample2"]
-    simulated_genome_path = results_path + 'simulated-genome/'
-    pipeline_directory = '/home/aaronfishman/temp-results/simulated-6/btb-seq-results/Results_simulated-reads_11Nov21/'
-    simulated_reads_path = results_path + 'simulated-reads/'
-    btb_seq_backup_path = results_path + 'btb-seq/'
-    btb_seq_results_path = results_path + 'btb-seq-results/'
-    mask_filepath = btb_seq_backup_path + "references/Mycbovis-2122-97_LT708304.fas.rpt.regions"
-
-
-    # Analyse
-    stats = []
-    for sample in samples:
-        simulated_snps = simulated_genome_path + sample + ".simulated.refseq2simseq.map.txt"
-        pipeline_snps = pipeline_directory + f'snpTables/{sample}_snps.tab'
-        stats.append(analyse(simulated_snps, pipeline_snps, mask_filepath))
-
-    stats = pd.DataFrame(stats)
-
 def checkout(repo_path, branch):
     run(["git", "checkout", str(branch)], cwd=repo_path)
 
@@ -217,9 +195,4 @@ def main():
     performance_test(args.results, args.btb_seq, args.ref, args.branch)
 
 if __name__ == '__main__':
-    results = '/home/aaronfishman/temp-results/simulated-6/'
-    btb_seq_path = '/home/aaronfishman/repos/btb-seq/'
-    ref = DEFAULT_REFERENCE_PATH
-    run(["sudo", "rm", "-r", results])
-    performance_test(results, btb_seq_path, ref)
-    # main()
+     main()

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -123,9 +123,9 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     btb_seq_results_path = results_path + 'btb-seq-results/'
 
     # Paths to simulated reference genome and simulated SNPs file
-    fasta_path = simulated_genome_path + 'simulated.simseq.genome.fa'
-    simulated_snps = simulated_genome_path + "simulated.refseq2simseq.map.txt"
-    mask_filepath = btb_seq_backup_path + "references/Mycbovis-2122-97_LT708304.fas.rpt.regions"
+    # fasta_path = simulated_genome_path + 'simulated.simseq.genome.fa'
+    # simulated_snps = simulated_genome_path + "simulated.refseq2simseq.map.txt"
+    # mask_filepath = btb_seq_backup_path + "references/Mycbovis-2122-97_LT708304.fas.rpt.regions"
 
     # TODO: handle dwgsim vcf files. Make sure we are taking into account variants it might generate
 
@@ -152,9 +152,9 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     simulate_genome(reference_path, simulated_genome_path + 'sample2.', seed=666)
 
     # Simulate Reads
-
-
-    simulate_reads(fasta_path, simulated_reads_path)
+    for sample in samples:
+        fasta_path = simulated_genome_path + sample + '.simulated.simseq.genome.fa'
+        simulate_reads(fasta_path, simulated_reads_path)
 
     # Analyse
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -145,9 +145,18 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     if branch:
         checkout(btb_seq_backup_path, branch)
 
-    # Run Simulation
-    simulate_genome(reference_path, simulated_genome_path)
+    # Prepare Genomes
+    samples = ["sample1", "sample2"]
+
+    simulate_genome(reference_path, simulated_genome_path + 'sample1.', seed=1)
+    simulate_genome(reference_path, simulated_genome_path + 'sample2.', seed=666)
+
+    # Simulate Reads
+
+
     simulate_reads(fasta_path, simulated_reads_path)
+
+    # Analyse
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)
 
     # Analyse Results
@@ -178,4 +187,9 @@ def main():
     performance_test(args.results, args.btb_seq, args.ref, args.branch)
 
 if __name__ == '__main__':
-    main()
+    results = '/home/aaronfishman/temp-results/simulated-6/'
+    btb_seq = '/home/aaronfishman/repos/btb-seq/'
+    ref = DEFAULT_REFERENCE_PATH
+    run(["sudo", "rm", "-r", results])
+    performance_test(results, btb_seq, ref)
+    # main()

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -41,7 +41,8 @@ def simulate_genome(reference_path, output_path, num_snps=16000):
 
 def simulate_reads(
     genome_fasta,
-    output_path,
+    output_directory,
+    sample_name="simulated",
     num_read_pairs=150000,
     read_length=150,
     seed=1,
@@ -51,10 +52,10 @@ def simulate_reads(
     indel_mutation_fraction=0,
     indel_extension_probability=0,
     per_base_error_rate="0" # TODO: default to Ele's reccomendation? 0.001-0.01
-):
-    output_prefix = output_path + "simulated"
+):   
     
     # How dwgsim chooses to name it's output fastq files
+    output_prefix = output_directory + sample_name
     dwgsim_read_1 = output_prefix + ".bwa.read1.fastq.gz"
     dwgsim_read_2 = output_prefix + ".bwa.read2.fastq.gz"
 
@@ -147,7 +148,6 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
 
     # Prepare Genomes
     samples = ["sample1", "sample2"]
-
     
     simulate_genome(reference_path, simulated_genome_path + 'sample2.')
 
@@ -158,7 +158,7 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
         # TODO: explicitly path fasta path to simulate
         fasta_path = simulated_genome_path + sample + '.simulated.simseq.genome.fa'
 
-        simulate_reads(fasta_path, simulated_reads_path)
+        simulate_reads(fasta_path, simulated_reads_path, sample_name=sample)
 
     # Analyse
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -129,8 +129,6 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     """ Runs a performance test against the pipeline
 
         Parameters:
-            predef_snp_path (str): Path to gzipped VCF (vcf.gz) file containing predefined SNPs from snippy
-            num_snps (int): Number of manually introduced SNPs, not used if predef_snp_path parameter is set
             btb_seq_path (str): Path to btb-seq code is stored
             results_path (str): Output path to performance test results
             reference_path (str): Path to reference fasta
@@ -185,7 +183,7 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     
     # Simulate Reads
     for sample in samples:
-        simulate_genome(reference_path, simulated_genome_path + sample + '.')
+        simulate_genome_random_snps(reference_path, simulated_genome_path + sample + '.')
 
         # TODO: explicitly path fasta path to simulate
         fasta_path = simulated_genome_path + sample + '.simulated.simseq.genome.fa'

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -126,7 +126,6 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     btb_seq_results_path = results_path + 'btb-seq-results/'
 
     # Paths to simulated reference genome and simulated SNPs file
-    # simulated_snps = simulated_genome_path + "simulated.refseq2simseq.map.txt"
     mask_filepath = btb_seq_backup_path + "references/Mycbovis-2122-97_LT708304.fas.rpt.regions"
 
     # TODO: handle dwgsim vcf files. Make sure we are taking into account variants it might generate

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -148,12 +148,16 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     # Prepare Genomes
     samples = ["sample1", "sample2"]
 
-    simulate_genome(reference_path, simulated_genome_path + 'sample1.', seed=1)
-    simulate_genome(reference_path, simulated_genome_path + 'sample2.', seed=666)
+    
+    simulate_genome(reference_path, simulated_genome_path + 'sample2.')
 
     # Simulate Reads
     for sample in samples:
+        simulate_genome(reference_path, simulated_genome_path + sample + '.')
+
+        # TODO: explicitly path fasta path to simulate
         fasta_path = simulated_genome_path + sample + '.simulated.simseq.genome.fa'
+
         simulate_reads(fasta_path, simulated_reads_path)
 
     # Analyse
@@ -188,8 +192,8 @@ def main():
 
 if __name__ == '__main__':
     results = '/home/aaronfishman/temp-results/simulated-6/'
-    btb_seq = '/home/aaronfishman/repos/btb-seq/'
+    btb_seq_path = '/home/aaronfishman/repos/btb-seq/'
     ref = DEFAULT_REFERENCE_PATH
     run(["sudo", "rm", "-r", results])
-    performance_test(results, btb_seq, ref)
+    performance_test(results, btb_seq_path, ref)
     # main()

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -162,9 +162,8 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)
 
     # Analyse Results
-    # HACK: this could easily break if additioanl files are present
+    # HACK: this could easily break if additional files are present
     pipeline_directory = glob.glob(btb_seq_results_path + 'Results_simulated-reads_*')[0] + '/'
-    pipeline_snps = pipeline_directory + 'snpTables/simulated_snps.tab'
 
     # Analyse
     stats = []

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -158,14 +158,13 @@ def performance_test(results_path, btb_seq_path, reference_path, exist_ok=False,
 
         simulate_reads(fasta_path, simulated_reads_path, sample_name=sample)
 
-    # Analyse
+    # Run the pipeline
     btb_seq(btb_seq_backup_path, simulated_reads_path, btb_seq_results_path)
 
     # Analyse Results
     # HACK: this could easily break if additional files are present
     pipeline_directory = glob.glob(btb_seq_results_path + 'Results_simulated-reads_*')[0] + '/'
 
-    # Analyse
     stats = []
     for sample in samples:
         simulated_snps = simulated_genome_path + sample + ".simulated.refseq2simseq.map.txt"


### PR DESCRIPTION
Functionality to run multiple samples in the benchmarking tool. Currently runs two random snps samples, but is extendable for larger sets. 
- `simulate_reads` has greater flexibility to name output reads
- `performance_test` method now simulates multiple samples before executing a single `btb-seq` run. The results from the run are analysed individually using existing functions and then collated into an output csv table that replaces the `json.stats`