### PR TITLE
Fix stats

### DIFF
--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -82,7 +82,7 @@ def analyse(simulated_snps, pipeline_snps, mask_filepath):
         "sensitivity": sensitivity,
         "miss_rate": miss_rate,
         "f_score": f_score,
-	"total_errors": total_errors
+        "total_errors": total_errors
     }
 
 #TODO: This may not be required if we can get away with using bcftools/vcftools

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -65,6 +65,9 @@ def analyse(simulated_snps, pipeline_snps, mask_filepath):
     # miss rate as FN/(TP + FN)
     miss_rate = fn / (tp + fn)
 
+    # F-score as 2*(precision*recall)/(precision-recall)
+    f_score = 2*(precision*sensitivity)/(precision+sensitivity)
+
     #  total number of errors (FP + FN) per million sequenced bases
     total_errors = fp + fn
 
@@ -78,7 +81,8 @@ def analyse(simulated_snps, pipeline_snps, mask_filepath):
         "precision": precision,
         "sensitivity": sensitivity,
         "miss_rate": miss_rate,
-        "total_errors": total_errors
+        "f_score": f_score,
+	"total_errors": total_errors
     }
 
 #TODO: This may not be required if we can get away with using bcftools/vcftools

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -37,25 +37,22 @@ def analyse(simulated_snps, pipeline_snps, mask_filepath):
     pipeline_pos = set(pipeline['POS'].values)
     masked_pos = set(masked_positions(mask_filepath))
 
-    simulated_pos_adjusted = simulated_pos - masked_pos
-    pipeline_pos_adjusted = pipeline_pos - masked_pos
-
     # TP - true positive -(the variant is in the simulated genome and correctly called by the pipeline)
-    tp = len(simulated_pos.intersection(pipeline_pos_adjusted))
+    tp = len(simulated_pos.intersection(pipeline_pos))
 
     # FP (the pipeline calls a variant that is not in the simulated genome),
-    fp = len(pipeline_pos_adjusted - simulated_pos_adjusted)
+    fp = len(pipeline_pos - simulated_pos)
 
     # FN SNP calls (the variant is in the simulated genome but the pipeline does not call it).
-    fn =  len(simulated_pos_adjusted - pipeline_pos_adjusted)
+    fn =  len(simulated_pos - pipeline_pos)
 
-    # TPs excluded 
+    # TPs in masked regions 
     masked_tp = len(masked_pos.intersection(simulated_pos.intersection(pipeline_pos)))
 
-    # FPs excluded
+    # FPs in masked regions
     masked_fp = len(masked_pos.intersection(pipeline_pos - simulated_pos))
 
-    # FNs excluded
+    # FNs in masked regions
     masked_fn = len(masked_pos.intersection(simulated_pos - pipeline_pos))
 
     # Compute Performance Stats

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -47,13 +47,13 @@ def analyse(simulated_snps, pipeline_snps, mask_filepath):
     fn =  len(simulated_pos - pipeline_pos)
 
     # TPs in masked regions 
-    masked_tp = len(masked_pos.intersection(simulated_pos.intersection(pipeline_pos)))
+    tp_in_mask = len(masked_pos.intersection(simulated_pos.intersection(pipeline_pos)))
 
     # FPs in masked regions
-    masked_fp = len(masked_pos.intersection(pipeline_pos - simulated_pos))
+    fp_in_mask = len(masked_pos.intersection(pipeline_pos - simulated_pos))
 
     # FNs in masked regions
-    masked_fn = len(masked_pos.intersection(simulated_pos - pipeline_pos))
+    fn_in_mask = len(masked_pos.intersection(simulated_pos - pipeline_pos))
 
     # Compute Performance Stats
     # precision (positive predictive value) of each pipeline as TP/(TP + FP), 
@@ -75,9 +75,9 @@ def analyse(simulated_snps, pipeline_snps, mask_filepath):
         "TP": tp,
         "FP": fp,
         "FN": fn,
-        "masked TPs": masked_tp,
-        "masked FPs": masked_fp,
-        "masked FNs": masked_fn,
+        "masked TPs": tp_in_mask,
+        "masked FPs": fp_in_mask, 
+        "masked FNs": fn_in_mask, 
         "precision": precision,
         "sensitivity": sensitivity,
         "miss_rate": miss_rate,


### PR DESCRIPTION
This PR changes the way TP, FP and FN scores are reported.

TP, FP and FN now include positions which intersect masked regions.

All other stats are calculated from these TP, FP and FN metrics.

Additional F-score stat is also now included.