### PR TITLE
increasing default number of read pairs to 10x

### DIFF
--- a/sim/sample.py
+++ b/sim/sample.py
@@ -31,7 +31,7 @@ class VcfSample(Sample):
         predef_snp_path, 
         seed=1, 
         per_base_error_rate="0",
-        num_read_pairs = 10,
+        num_read_pairs = 144997,
     ):
         self.seed = seed
         self.per_base_error_rate = per_base_error_rate


### PR DESCRIPTION
Increasing default number of read pairs for VcfSamples to 144997 (10-fold coverage), a more sensible baseline 