### PR TITLE
Data sets

### DIFF
--- a/sim/sample.py
+++ b/sim/sample.py
@@ -180,6 +180,15 @@ class RandomSample(Sample):
 
 
 def vcf_samples(datasets, snippy_dir='/mnt/fsx-027/snippy/'):
+    """ Returns a list of VcfSample objects built from data sets contained
+        in the datasets parameter. Each object is instantiated with a 
+        unique seed value
+
+        Parameters:
+            datasets (tuple (str)): elements describe the base directory name
+                for each dataset
+            snippy_dir (str): path of parent directory of datasets
+    """
     vcf_filepaths = []
     for set_i in datasets:
         vcf_dir = snippy_dir + set_i
@@ -199,20 +208,35 @@ def vcf_samples(datasets, snippy_dir='/mnt/fsx-027/snippy/'):
     return samples
 
 def quick_samples():
+    """ Returns a list containing a single RandomSample object
+    """
     return [RandomSample(seed=1)]
 
 def random_samples():
+    """ Returns a list containing two RandomSample objects 
+    """
     return [RandomSample(seed=1, per_base_error_rate="0.001-0.01"),
             RandomSample(seed=666, per_base_error_rate="0.001-0.01")]
 
 def standard_samples():
-    return vcf_samples(('standard',)) + random_samples()
+    """ Returns a list of Sample objects for the standard dataset
+    """
+    samples = vcf_samples(('standard',)) + random_samples() 
+    return samples
 
 def aph_samples():
+    """ Returns a list of Sample objects for the aph dataset
+    """
     return vcf_samples(('aph',))
 
 def zwyer_samples():
+    """ Returns a list of Sample objects for the zwyer dataset 
+    """
     return vcf_samples(('zwyer',))
 
 def all_samples():
-    return vcf_samples(('aph', 'zwyer')) + random_samples()
+    """ Returns a list of Sample objects for all VCF samples and two
+        random samples
+    """
+    samples = vcf_samples(('aph', 'zwyer')) + random_samples()
+    return samples

--- a/sim/sample.py
+++ b/sim/sample.py
@@ -2,6 +2,7 @@ from utils import run
 import errno
 import math 
 import os
+import glob
 
 class Sample:
 
@@ -176,3 +177,42 @@ class RandomSample(Sample):
                     "-indel_count", str(self.num_indels),
                     "-seed", str(self.seed)]
         self._simulate_genome_base(reference_path, simulated_genome_path, params)
+
+
+def vcf_samples(datasets, snippy_dir='/mnt/fsx-027/snippy/'):
+    vcf_filepaths = []
+    for set_i in datasets:
+        vcf_dir = snippy_dir + set_i
+        if not os.path.isdir(vcf_dir):
+            raise Exception("Predefined SNP directory not found") 
+        vcf_dir = os.path.join(vcf_dir, '')
+        vcf_filepaths.extend(glob.glob(vcf_dir+'*.vcf'))
+    
+    # sort vcf_filepaths for using consistent seed values accross runs
+    vcf_filepaths.sort()
+    samples = []
+    seed_value = 0
+    for filepath in vcf_filepaths:
+        seed_value+=1 # different seed value for each sample
+        samples.append(VcfSample(filepath, seed=seed_value, per_base_error_rate="0.001-0.01"))    
+
+    return samples
+
+def quick_samples():
+    return [RandomSample(seed=1)]
+
+def random_samples():
+    return [RandomSample(seed=1, per_base_error_rate="0.001-0.01"),
+            RandomSample(seed=666, per_base_error_rate="0.001-0.01")]
+
+def standard_samples():
+    return vcf_samples(('standard',)) + random_samples()
+
+def aph_samples():
+    return vcf_samples(('aph',))
+
+def zwyer_samples():
+    return vcf_samples(('zwyer',))
+
+def all_samples():
+    return vcf_samples(('aph', 'zwyer')) + random_samples()

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -12,61 +12,9 @@ from utils import run
 
 DEFAULT_REFERENCE_PATH = './Mycobacterium_bovis_AF212297_LT78304.fa'
 
-
 def btb_seq(btb_seq_directory, reads_directory, results_directory):
     run(["bash", "./btb-seq", reads_directory,
          results_directory], cwd=btb_seq_directory)
-
-# TODO: move these functions into samples
-
-def colate_vcf_samples(dataset, snippy_dir='/mnt/fsx-027/snippy/'):
-    vcf_dir = snippy_dir + dataset
-    if not os.path.isdir(vcf_dir):
-        raise Exception("Predefined SNP directory not found") 
-    
-    vcf_dir = os.path.join(vcf_dir, '')
-
-    vcf_filepaths = glob.glob(vcf_dir+'*.vcf')
-    
-    return vcf_filepaths
-
-def vcf_samples(datasets, snippy_dir='/mnt/fsx-027/snippy/'):
-    vcf_filepaths = []
-    for set_i in datasets:
-        vcf_dir = snippy_dir + set_i
-        if not os.path.isdir(vcf_dir):
-            raise Exception("Predefined SNP directory not found") 
-        vcf_dir = os.path.join(vcf_dir, '')
-        vcf_filepaths.extend(glob.glob(vcf_dir+'*.vcf'))
-    
-    # sort vcf_filepaths for using consistent seed values accross runs
-    vcf_filepaths.sort()
-    samples = []
-    seed_value = 0
-    for filepath in vcf_filepaths:
-        seed_value+=1 # different seed value for each sample
-        samples.append(VcfSample(filepath, seed=seed_value, per_base_error_rate="0.001-0.01"))    
-
-    return samples
-
-def quick_samples():
-    return [RandomSample(seed=1)]
-
-def random_samples():
-    return [RandomSample(seed=1, per_base_error_rate="0.001-0.01"),
-            RandomSample(seed=666, per_base_error_rate="0.001-0.01")]
-
-def standard_samples():
-    return vcf_samples(('standard',)) + random_samples()
-
-def aph_samples():
-    return vcf_samples(('aph',))
-
-def zwyer_samples():
-    return vcf_samples(('zwyer',))
-
-def all_samples():
-    return vcf_samples(('aph', 'zwyer')) + random_samples()
 
 def performance_test(
     results_path, 

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -56,6 +56,9 @@ def random_samples():
     return [RandomSample(seed=1, per_base_error_rate="0.001-0.01"),
             RandomSample(seed=666, per_base_error_rate="0.001-0.01")]
 
+def standard_samples():
+    return vcf_samples(('standard',)) + random_samples()
+
 def aph_samples():
     return vcf_samples(('aph',))
 
@@ -178,7 +181,7 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     # Run
-    samples = zwyer_samples()
+    samples = standard_samples()
 
     performance_test(
         args.results, 

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -19,30 +19,51 @@ def btb_seq(btb_seq_directory, reads_directory, results_directory):
 
 # TODO: move these functions into samples
 
-def quick_samples():
-    return [RandomSample(seed=1)]
-
-def standard_samples(vcf_dir='/mnt/fsx-027/snippy'):
+def colate_vcf_samples(dataset, snippy_dir='/mnt/fsx-027/snippy/'):
+    vcf_dir = snippy_dir + dataset
     if not os.path.isdir(vcf_dir):
         raise Exception("Predefined SNP directory not found") 
     
     vcf_dir = os.path.join(vcf_dir, '')
 
     vcf_filepaths = glob.glob(vcf_dir+'*.vcf')
-    # sort vcf_filepaths to for using consistent seed values accross runs.
+    
+    return vcf_filepaths
+
+def vcf_samples(datasets, snippy_dir='/mnt/fsx-027/snippy/'):
+    vcf_filepaths = []
+    for set_i in datasets:
+        vcf_dir = snippy_dir + set_i
+        if not os.path.isdir(vcf_dir):
+            raise Exception("Predefined SNP directory not found") 
+        vcf_dir = os.path.join(vcf_dir, '')
+        vcf_filepaths.extend(glob.glob(vcf_dir+'*.vcf'))
+    
+    # sort vcf_filepaths for using consistent seed values accross runs
     vcf_filepaths.sort()
-
     samples = []
-
-    samples += [RandomSample(seed=1,per_base_error_rate="0.001-0.01"),
-    RandomSample(seed=666,per_base_error_rate="0.001-0.01")]
-
     seed_value = 0
     for filepath in vcf_filepaths:
         seed_value+=1 # different seed value for each sample
         samples.append(VcfSample(filepath, seed=seed_value, per_base_error_rate="0.001-0.01"))    
 
     return samples
+
+def quick_samples():
+    return [RandomSample(seed=1)]
+
+def random_samples():
+    return [RandomSample(seed=1, per_base_error_rate="0.001-0.01"),
+            RandomSample(seed=666, per_base_error_rate="0.001-0.01")]
+
+def aph_samples():
+    return vcf_samples(('aph',))
+
+def zwyer_samples():
+    return vcf_samples(('zwyer',))
+
+def all_samples():
+    return vcf_samples(('aph', 'zwyer')) + random_samples()
 
 def performance_test(
     results_path, 
@@ -157,7 +178,7 @@ def main():
     args = parser.parse_args(sys.argv[1:])
 
     # Run
-    samples = standard_samples()
+    samples = zwyer_samples()
 
     performance_test(
         args.results, 
@@ -169,4 +190,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This PR enables new data sets for simulating genomes with predefined SNPs e.g. the full APH and the zwyer set.

It works with a new structure in the fsx drive.

The standard set is still available via function `standard_samples()`.

This also takes care of a TODO, which was to move the functions for building sample sets into samples.py