### PR TITLE
Stats at bases

### DIFF
--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -1,5 +1,3 @@
-from re import I
-from numpy.lib import utils
 import pandas as pd
 import glob 
 import os
@@ -155,9 +153,3 @@ def site_stats(simulated_snp_path, pipeline_snp_path, bcf_path):
 
     return df
 
-if __name__ == '__main__':
-    pipeline_snps = '/home/aaronfishman/temp/sites3/btb-seq-results/Results_simulated-reads_08Dec21/snpTables/RandomSample-snps16000-indels1600-seed1_snps.tab'
-    simulated_snps = '/home/aaronfishman/temp/sites3/simulated-genome/RandomSample-snps16000-indels1600-seed1.simulated.refseq2simseq.map.txt'
-    # bcf_path = '/home/aaronfishman/temp/ad0-not/btb-seq-results/Results_simulated-reads_07Dec21/filteredBcf/VcfSample-AF-12-00945-19-seed1-error0.001-0.01-readpairs-144997_filtered.bcf'
-    bcf_path = '/home/aaronfishman/temp/sites3/btb-seq-results/Results_simulated-reads_08Dec21//vcf/RandomSample-snps16000-indels1600-seed1.vcf.gz'
-    print(site_stats(simulated_snps, pipeline_snps, bcf_path))

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -137,16 +137,13 @@ def classify_sites(simulated_snp_path, pipeline_snp_path):
     return tp, fp, fn
 
 def site_stats(simulated_snp_path, pipeline_snp_path, bcf_path):
-    print("simulate", "*******")
-    print("simulate", simulated_snp_path)
-    print("pipeline_snp_path", pipeline_snp_path)
-    print("bcf_path", bcf_path)
+    """ A data frame that shows stats at each fp/fn site """
 
     tp, fp, fn = classify_sites(simulated_snp_path, pipeline_snp_path)
 
     # Summary Bcf
     df = bcf_summary(bcf_path)
-    df = df[(df.POS.isin(list(fp) + list(fn)))]   
+    df = df[df.POS.isin(list(fp) + list(fn))]
 
     # Error Type Column
     df['error_type'] = 'undefined'

--- a/sim/compare_snps.py
+++ b/sim/compare_snps.py
@@ -4,7 +4,7 @@ import glob
 import os
 from Bio import SeqIO
 
-from sim.utils import bcf_summary
+from utils import bcf_summary
 
 """
 Calculate performance stats from simulated data
@@ -132,3 +132,26 @@ def analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_fi
         "f_score": f_score,
         "total_errors": total_errors
     }
+
+if __name__ == '__main__':
+    pipeline_snps = '/home/aaronfishman/temp/ad0-not/btb-seq-results/Results_simulated-reads_07Dec21/snpTables/VcfSample-AF-12-00945-19-seed1-error0.001-0.01-readpairs-144997_snps.tab'
+    simulated_snps = '/home/aaronfishman/temp/ad0-not/simulated-genome/VcfSample-AF-12-00945-19-seed1-error0.001-0.01-readpairs-144997.simulated.refseq2simseq.map.txt'
+    # bcf_path = '/home/aaronfishman/temp/ad0-not/btb-seq-results/Results_simulated-reads_07Dec21/filteredBcf/VcfSample-AF-12-00945-19-seed1-error0.001-0.01-readpairs-144997_filtered.bcf'
+    bcf_path = '/home/aaronfishman/temppp.bcf'
+
+    tp, fp, fn = classify_sites(simulated_snps, pipeline_snps)
+
+    print('tp', tp)
+
+    X = ['fp']*len(fp) + ['fn']*len(fn)
+    Y = list(fp) + list(fn)
+    print('X', X)
+    print('Y', Y)
+    error_type = [x for _, x in sorted(zip(Y, X))]
+    print('error type', error_type)
+
+    df = bcf_summary(bcf_path)
+    df = df[(df.POS.isin(list(fp) + list(fn)))]
+    df['AD1/(AD1+AD0)'] = df['AD1'] / (df['AD1'] + df['AD0'])
+    # df['error_type'] = error_type
+    print(df)

--- a/sim/temp.bash
+++ b/sim/temp.bash
@@ -1,4 +1,0 @@
-# 'bcftools query -f '%INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n' /home/aaronfishman/temp/filtered.vcf
-
-bcftools query -f '%POS, %INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n' \
-'/home/aaronfishman/temp/sites1/btb-seq-results/Results_simulated-reads_08Dec21/vcf/RandomSample-snps16000-indels1600-seed1.vcf.gz'

--- a/sim/temp.bash
+++ b/sim/temp.bash
@@ -1,3 +1,4 @@
 # 'bcftools query -f '%INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n' /home/aaronfishman/temp/filtered.vcf
 
-PATH=
+bcftools query -f '%POS, %INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n' \
+'/home/aaronfishman/temp/sites1/btb-seq-results/Results_simulated-reads_08Dec21/vcf/RandomSample-snps16000-indels1600-seed1.vcf.gz'

--- a/sim/temp.bash
+++ b/sim/temp.bash
@@ -1,0 +1,3 @@
+# 'bcftools query -f '%INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n' /home/aaronfishman/temp/filtered.vcf
+
+PATH=

--- a/sim/utils.py
+++ b/sim/utils.py
@@ -22,23 +22,13 @@ def run(cmd, *args, **kwargs):
             cmd failed with exit code %i
           *****""" % (cmd, returncode))
 
-def bcf_summary(filepath='/home/aaronfishman/temp/filtered.vcf', exclude=None):
-    # excluded sites
-    if exclude:
-        exclusion_criteria = 'POS==' + ' || POS=='.join(str(x) for x in exclude)
-    else:
-        exclusion_criteria = '1<0'
-
-    print('exclusion criteris', exclusion_criteria)
-    
-    # query BCF/VCF
+def bcf_summary(filepath='/home/aaronfishman/temp/filtered.vcf'):
+    # Query
     columns = ['POS', 'AD0', 'AD1', 'DP']
     text = subprocess.check_output(["bcftools", "query", "-f",
         '%POS, %INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n',
-        # '-e', exclusion_criteria,
-        '-e', 'INFO/AD[1]==0',
         filepath
     ], text=True)
     
-    # construct data frame
+    # Construct data frame
     return pd.read_csv(StringIO(text), header=None, names=columns)

--- a/sim/utils.py
+++ b/sim/utils.py
@@ -25,15 +25,18 @@ def run(cmd, *args, **kwargs):
 def bcf_summary(filepath='/home/aaronfishman/temp/filtered.vcf', exclude=None):
     # excluded sites
     if exclude:
-        exclusion_criteria = 'POS=='+' || POS=='.join(str(x) for x in exclude)
+        exclusion_criteria = 'POS==' + ' || POS=='.join(str(x) for x in exclude)
     else:
         exclusion_criteria = '1<0'
+
+    print('exclusion criteris', exclusion_criteria)
     
     # query BCF/VCF
     columns = ['POS', 'AD0', 'AD1', 'DP']
     text = subprocess.check_output(["bcftools", "query", "-f",
         '%POS, %INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n',
-        '-e', exclusion_criteria,
+        # '-e', exclusion_criteria,
+        '-e', 'INFO/AD[1]==0',
         filepath
     ], text=True)
     

--- a/sim/utils.py
+++ b/sim/utils.py
@@ -22,13 +22,20 @@ def run(cmd, *args, **kwargs):
             cmd failed with exit code %i
           *****""" % (cmd, returncode))
 
-def bcf_summary(filepath='/home/aaronfishman/temp/filtered.vcf'):
-      
+def bcf_summary(filepath='/home/aaronfishman/temp/filtered.vcf', exclude=None):
+    # excluded sites
+    if exclude:
+        exclusion_criteria = 'POS=='+' || POS=='.join(str(x) for x in exclude)
+    else:
+        exclusion_criteria = '1<0'
+    
+    # query BCF/VCF
+    columns = ['POS', 'AD0', 'AD1', 'DP']
     text = subprocess.check_output(["bcftools", "query", "-f",
         '%POS, %INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n',
+        '-e', exclusion_criteria,
         filepath
     ], text=True)
     
-    return pd.read_csv(StringIO(text), header=None,
-        names = ['POS', 'AD0', 'AD1', 'DP']
-    )
+    # construct data frame
+    return pd.read_csv(StringIO(text), header=None, names=columns)

--- a/sim/utils.py
+++ b/sim/utils.py
@@ -1,4 +1,6 @@
 import subprocess
+import pandas as pd
+from io import StringIO
 
 def run(cmd, *args, **kwargs):
     """ Run a command and assert that the process exits with a non-zero exit code.
@@ -19,3 +21,14 @@ def run(cmd, *args, **kwargs):
             %s
             cmd failed with exit code %i
           *****""" % (cmd, returncode))
+
+def bcf_summary(filepath='/home/aaronfishman/temp/filtered.vcf'):
+      
+    text = subprocess.check_output(["bcftools", "query", "-f",
+        '%POS, %INFO/AD{0}, %INFO/AD{1}, %INFO/DP\n',
+        filepath
+    ], text=True)
+    
+    return pd.read_csv(StringIO(text), header=None,
+        names = ['POS', 'AD0', 'AD1', 'DP']
+    )

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -6,7 +6,7 @@ import shutil
 
 import pandas as pd
 
-from compare_snps import analyse
+import compare_snps
 from sample import *
 from utils import run
 
@@ -94,24 +94,32 @@ def performance_test(
         pipeline_snp_path = pipeline_directory + f'snpTables/{sample.name}_snps.tab'
         if not os.path.exists(pipeline_snp_path):
             pipeline_snp_path = pipeline_directory + f'snpTables/{sample.name}.tab'
+        
         if not os.path.exists(pipeline_snp_path):
             raise Exception("Cant Find the pipeline's snps table!!")
+        
         simulated_snp_path = results_path + f'simulated-genome/{sample.name}.simulated.refseq2simseq.map.txt'
         pipeline_genome_path = pipeline_directory + f'consensus/{sample.name}_consensus.fas'
+        
         if not os.path.exists(pipeline_genome_path):
             pipeline_genome_path = pipeline_directory + f'consensus/{sample.name}.fas'
+        
         if not os.path.exists(pipeline_snp_path):
             raise Exception("Cant Find the pipeline's consensus file!!")
         
-        stat = analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_filepath)
+        # Performance Stats
+        stat = compare_snps.sanalyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_filepath)
         stat["name"] = sample.name
         
         stats.append(stat)
 
+        # Base Stats
+        tp, fp, fn = compare_snps.classify_sites(simulated_snp_path, pipeline_snp_path)
+        df = compare_snps.bcf_summary(simulated_snp_path, exclude=tp)
+
     stats_table = pd.DataFrame(stats)
 
     path = results_path + "stats.csv"
-    print("***printing to path***")
     stats_table.to_csv(path)
 
 def checkout(repo_path, branch):

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -66,6 +66,7 @@ def performance_test(
     os.makedirs(simulated_genome_path, exist_ok=exist_ok)
     os.makedirs(simulated_reads_path, exist_ok=exist_ok)
     os.makedirs(btb_seq_results_path, exist_ok=exist_ok)
+    os.makedirs(site_stats_path, exist_ok=exist_ok)
 
     # Backup btb-seq code
     # TODO: exclude the work/ subdirectory from this operation.


### PR DESCRIPTION
Metrics for each FN/FP site
- `bcf_summary` function that creates a summary dataframe of a bcf/vcf using `bcftools` 
- `classify_sites` that determines the tp/fp/fn sites
- `site_stats()` function creates a summary dataframe at fp/fn sites
- `performance_test` generates a site stats csv for each sample under the `site-stats/` directory