### PR TITLE
No bfast

### DIFF
--- a/sim/sample.py
+++ b/sim/sample.py
@@ -69,6 +69,7 @@ class Sample:
             "-X", str(indel_extension_probability),
             "-y", str(random_dna_probability),
             "-H",
+            "-o", "1",
             "-z", str(seed),
             genome_fasta_path,
             output_prefix


### PR DESCRIPTION
Avoids unnecessary bfast style reads from being generated by dwgsim