### PR TITLE
Sequence and benchmark

### DIFF
--- a/sim/genome.py
+++ b/sim/genome.py
@@ -21,11 +21,6 @@ class SimulatedGenome:
         
         self.name = name
 
-# RandomSample-snps0-indels3898-seed1.simulated.refseq2simseq.INDEL.vcf
-# RandomSample-snps0-indels3898-seed1.simulated.refseq2simseq.SNP.vcf
-# RandomSample-snps0-indels3898-seed1.simulated.refseq2simseq.map.txt
-# RandomSample-snps0-indels3898-seed1.simulated.simseq.genome.fa
-
 def from_directory(path):
     """ List of SimulatedGenome from directory """
     # Initialise
@@ -46,10 +41,3 @@ def from_directory(path):
         samples.append(SimulatedGenome(name, genome_path, snp_table_path, snp_vcf_path, indel_vcf_path))
 
     return samples
-
-if __name__ == '__main__':
-    path = os.path.expanduser('~/temp/bfast-genomes-3/')
-
-    samples = from_directory(path)
-
-    print(samples)

--- a/sim/genome.py
+++ b/sim/genome.py
@@ -33,9 +33,8 @@ def from_directory(path):
     path = os.path.join(path, '')
     filepaths = glob.glob(path + f'*{postfix}')
 
-    samples = []
-
     # Construct
+    samples = []
     for filepath in filepaths:
         name = os.path.basename(filepath[:-len(postfix)])
         
@@ -47,7 +46,7 @@ def from_directory(path):
         samples.append(SimulatedGenome(name, genome_path, snp_table_path, snp_vcf_path, indel_vcf_path))
 
     return samples
-    
+
 if __name__ == '__main__':
     path = os.path.expanduser('~/temp/bfast-genomes-3/')
 

--- a/sim/genome.py
+++ b/sim/genome.py
@@ -1,4 +1,5 @@
 import os
+import glob
 
 import utils
 
@@ -19,3 +20,37 @@ class SimulatedGenome:
         self.indel_vcf_path = indel_vcf_path
         
         self.name = name
+
+# RandomSample-snps0-indels3898-seed1.simulated.refseq2simseq.INDEL.vcf
+# RandomSample-snps0-indels3898-seed1.simulated.refseq2simseq.SNP.vcf
+# RandomSample-snps0-indels3898-seed1.simulated.refseq2simseq.map.txt
+# RandomSample-snps0-indels3898-seed1.simulated.simseq.genome.fa
+
+def from_directory(path):
+    """ List of SimulatedGenome from directory """
+    # Initialise
+    postfix = '.simulated.simseq.genome.fa'
+    path = os.path.join(path, '')
+    filepaths = glob.glob(path + f'*{postfix}')
+
+    samples = []
+
+    # Construct
+    for filepath in filepaths:
+        name = os.path.basename(filepath[:-len(postfix)])
+        
+        genome_path = path + name + '.simulated.simseq.genome.fa'
+        snp_table_path = path + name + '.simulated.refseq2simseq.map.txt'
+        snp_vcf_path = path + name + '.simulated.refseq2simseq.SNP.vcf'
+        indel_vcf_path = path + name + '.simulated.refseq2simseq.INDEL.vcf'
+
+        samples.append(SimulatedGenome(name, genome_path, snp_table_path, snp_vcf_path, indel_vcf_path))
+
+    return samples
+    
+if __name__ == '__main__':
+    path = os.path.expanduser('~/temp/bfast-genomes-3/')
+
+    samples = from_directory(path)
+
+    print(samples)

--- a/sim/processed.py
+++ b/sim/processed.py
@@ -1,4 +1,4 @@
-
+import utils
 
 class ProcessedSample:
     """ simulated genomes combined with and btb-seq sequence data 
@@ -20,23 +20,14 @@ def from_list(genomes, sequenced):
         Throws an error if the sample names are not consistent.
     """
 
+    # Validate
+    if not utils.names_consistent(genomes, sequenced):
+        raise Exception("Genome names inconsistent with sequenced names")
+
+    # Match
     genome_dict = {g.name: g for g in genomes}
     sequenced_dict = {s.name: s for s in sequenced}
 
-    # Validate
-    if len(genome_dict) != len(genomes):
-        raise Exception("Genomes with non-unique names found")
-
-    if len(sequenced_dict) != len(sequenced):
-        raise Exception("Sequenced samples with non-unique names found")
-
-    if set(genome_dict.keys()) != set(sequenced_dict.keys()):
-        raise Exception(f"""Genome sample names are different to sequenced sample names
-            Genomes: {genome_dict.keys()}
-            Sequenced: {sequenced_dict.keys()}
-        """)
-    
-    # Match
     samples = []
     for name in genome_dict:
         sample = ProcessedSample(genome_dict[name], sequenced_dict[name])

--- a/sim/reads.py
+++ b/sim/reads.py
@@ -36,9 +36,3 @@ def from_directory(path, read_1_postfix='_S1_R1_X.fastq.gz', read_2_postfix='_S1
         reads.append(Reads(read_1, read_2, name=name_1))
 
     return reads
-
-if __name__ == '__main__':
-    path = '/home/aaronfishman/temp/reads/'
-    reads = from_directory(path)
-    print('reads', reads)
-    print('reads', reads[0].name)

--- a/sim/reads.py
+++ b/sim/reads.py
@@ -1,0 +1,47 @@
+import os
+import glob
+
+class Reads:
+    """ A pair of fastq reads """
+    def __init__(self, read_1_path, read_2_path, name="unnamed"):
+        if not os.path.exists(read_1_path):
+            raise Exception("Could not find read ", read_1_path)
+
+        if not os.path.exists(read_2_path):
+            raise Exception("Could not find read ", read_2_path)
+
+        self.read_1_path = read_1_path
+        self.read_2_path = read_2_path
+        self.name = name
+
+def from_directory(path):
+    path = os.path.join(path, '')
+
+    read_1_postfix = '_S1_R1_X.fastq.gz'
+    read_2_postfix = '_S1_R2_X.fastq.gz'
+
+    # Find reads
+    read_1s = sorted(glob.glob(path + "*" + read_1_postfix))
+    read_2s = sorted(glob.glob(path + "*" + read_2_postfix))
+
+    if len(read_1s) != len(read_2s):
+        raise Exception(f"Number of R1 reads different to R2 reads: ({len(read_1s)}, {len(read_2s)})")
+
+    # Construct
+    reads = []
+    for read_1, read_2 in zip(read_1s, read_2s):
+        name_1 = os.path.basename(read_1)[:-len(read_1_postfix)]
+        name_2 = os.path.basename(read_2)[:-len(read_2_postfix)]
+
+        if name_1 != name_2:
+            raise Exception(f"Could not pair reads, inconsistent names: {name_1}, {name_2}")
+
+        reads.append(Reads(read_1, read_2, name=name_1))
+
+    return reads
+
+if __name__ == '__main__':
+    path = '/home/aaronfishman/temp/reads/'
+    reads = from_directory(path)
+    print('reads', reads)
+    print('reads', reads[0].name)

--- a/sim/reads.py
+++ b/sim/reads.py
@@ -14,13 +14,10 @@ class Reads:
         self.read_2_path = read_2_path
         self.name = name
 
-def from_directory(path):
+def from_directory(path, read_1_postfix='_S1_R1_X.fastq.gz', read_2_postfix='_S1_R2_X.fastq.gz'):
+    # Find reads
     path = os.path.join(path, '')
 
-    read_1_postfix = '_S1_R1_X.fastq.gz'
-    read_2_postfix = '_S1_R2_X.fastq.gz'
-
-    # Find reads
     read_1s = sorted(glob.glob(path + "*" + read_1_postfix))
     read_2s = sorted(glob.glob(path + "*" + read_2_postfix))
 
@@ -34,7 +31,7 @@ def from_directory(path):
         name_2 = os.path.basename(read_2)[:-len(read_2_postfix)]
 
         if name_1 != name_2:
-            raise Exception(f"Could not pair reads, inconsistent names: {name_1}, {name_2}")
+            raise Exception(f"Name mismatch, Could not pair reads: {name_1}, {name_2}")
 
         reads.append(Reads(read_1, read_2, name=name_1))
 

--- a/sim/temp.bash
+++ b/sim/temp.bash
@@ -1,0 +1,7 @@
+
+btb_seq=~/repos/btb-seq
+genomes=~/temp/bfast-genomes-3/
+reads=~/temp/bfast-reads-3/
+output=~/temp/sequence-4/
+sudo rm -r $output
+sudo python validator.py sequence $btb_seq $genomes $reads $output --light

--- a/sim/temp.bash
+++ b/sim/temp.bash
@@ -1,7 +1,0 @@
-
-btb_seq=~/repos/btb-seq
-genomes=~/temp/bfast-genomes-3/
-reads=~/temp/bfast-reads-3/
-output=~/temp/sequence-4/
-sudo rm -r $output
-sudo python validator.py sequence $btb_seq $genomes $reads $output --light

--- a/sim/unit_tests.py
+++ b/sim/unit_tests.py
@@ -54,10 +54,5 @@ def mock_name(name):
 def mock_names(names):
     return [mock_name(name) for name in names]
 
-class MockName():
-    def __init__(self, name):
-        self.name = name
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/sim/unit_tests.py
+++ b/sim/unit_tests.py
@@ -6,6 +6,8 @@ import genome
 
 import validator
 
+import utils
+
 class ValidatorTests(unittest.TestCase):
     def test_validator(self):
         """ A simple introductory unit test that checks we can run through the
@@ -34,6 +36,28 @@ class ValidatorTests(unittest.TestCase):
 
         # Run test
         validator.pipeline('./', './', [mock_sample])
+
+    def test_names_consistent(self):
+        """ Ensure names consistent works as expected """
+        self.assertTrue(utils.names_consistent([], []))
+        self.assertTrue(utils.names_consistent([mock_name("A")], [mock_name("A")]))
+        self.assertTrue(utils.names_consistent(mock_names("AB"), mock_names("BA")))
+        
+        self.assertFalse(utils.names_consistent(mock_names("ABB"), mock_names("ABB")))
+        self.assertFalse(utils.names_consistent(mock_names("ABC"), mock_names("ABD")))
+
+def mock_name(name):
+    mock = Mock()
+    mock.name = name
+    return mock
+
+def mock_names(names):
+    return [mock_name(name) for name in names]
+
+class MockName():
+    def __init__(self, name):
+        self.name = name
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sim/utils.py
+++ b/sim/utils.py
@@ -47,3 +47,21 @@ def checkout(repo_path, branch):
 def assert_path_exists(path):
     if not os.path.exists(path):
         raise Exception("Could not find path: ", path)
+
+def names_consistent(x, y):
+    """ True if the name properties between two lists are consistent and unique. False otherwise """
+
+    x_dict = {X.name: X for X in x}
+    y_dict = {Y.name: Y for Y in y}
+
+    # Validate
+    if len(x_dict) != len(x):
+        return False
+
+    if len(y_dict) != len(y):
+        return False
+
+    if set(x_dict.keys()) != set(y_dict.keys()):
+        return False
+
+    return True

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -12,6 +12,7 @@ import compare_snps
 import sequenced
 import processed
 import genome
+import reads
 
 import config
 
@@ -118,7 +119,10 @@ def pipeline(
 def sequence_and_benchmark(btb_seq_path, genomes_path, reads_path, output_path, light_mode):
     # Load
     genomes = genome.from_directory(genomes_path)
-    
+    read_pairs = reads.from_directory(reads_path)
+
+    if not utils.names_consistent(genomes, read_pairs):
+        raise Exception("Genomes and read names not consistent")
 
     # Initialise
     results_path = os.path.join(output_path, 'sequenced')

--- a/sim/validator.py
+++ b/sim/validator.py
@@ -116,9 +116,11 @@ def pipeline(
         shutil.rmtree(results_path)
 
 def sequence_and_benchmark(btb_seq_path, genomes_path, reads_path, output_path, light_mode):
-    # Initialise
+    # Load
     genomes = genome.from_directory(genomes_path)
+    
 
+    # Initialise
     results_path = os.path.join(output_path, 'sequenced')
     stats_path = os.path.join(output_path, 'stats')
     btb_seq_backup_path = os.path.join(output_path, 'btb-seq')
@@ -133,6 +135,7 @@ def sequence_and_benchmark(btb_seq_path, genomes_path, reads_path, output_path, 
     stats, site_stats = compare_snps.benchmark(processed_samples)
 
     # Save
+    # TODO: consolidate with pipeline()
     stats.to_csv(output_path + '/stats.csv')
 
     for name, df in site_stats.items():


### PR DESCRIPTION
Functionality to sequence and benchmark preprocessed reads and genomes:
- `sequence` option on the cli parser that runs the new `sequence_and_benchmark` method
- `sequence()` returns SequencedSample objects for added convenience
- `from_directory()` option on `genomes`
- `Reads` class for containing paths paired reads
- DRYed up testing that lists of names are consistent with `test_names_consistent` (+ unit tests!)