### PR TITLE
masked stats

### DIFF
--- a/compare_snps.py
+++ b/compare_snps.py
@@ -92,7 +92,7 @@ def analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_fi
         "TP": n_tp,
         "FP": n_fp,
         "FN": n_fn,
-        "misssing_sites": n_n_pos,
+        "missing_sites": n_n_pos,
         "precision": precision,
         "sensitivity": sensitivity,
         "miss_rate": miss_rate,

--- a/validator.py
+++ b/validator.py
@@ -127,10 +127,11 @@ def benchmark(genomes_path, results_path, output_path):
     os.makedirs(stats_path, exist_ok=False)
 
     # Benchmark
-    stats, site_stats = compare_snps.benchmark(processed_samples)
+    stats, stats_masked, site_stats = compare_snps.benchmark(processed_samples)
 
     # Save
     stats.to_csv(output_path + '/stats.csv')
+    stats_masked.to_csv(output_path + '/stats_masked.csv')
     for name, df in site_stats.items():
         df.to_csv(stats_path + f'/{name}_stats.csv')
 


### PR DESCRIPTION
This PR updates the `analyse()` function in `compare_snps.py` to include an optional argument which is the filepath to the mask. If included, the function will subtract masked regions from TP, FP and FN sites prior to calculating stats.

`benchmark()` now includes two calls to `analyse()`, where one produces stats without masking and the other produces stats with masking.

Two stats.csv files are written in `validator.py`.

TPs, FPs and FNs, in the mask are no longer reported in  stats.csv: these metrics are implicit in the difference between masked and unmasked TPs, FPs and FNs. 