### PR TITLE
Masking bug fix

### DIFF
--- a/compare_snps.py
+++ b/compare_snps.py
@@ -55,9 +55,9 @@ def analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_fi
         masked_pos = set(masked_positions(mask_filepath))
 
         # TPs, FPs and FNs in masked regions 
+        fn.update(tp.intersection(masked_pos)) 
         tp = tp.difference(masked_pos)
         fp = fp.difference(masked_pos) 
-        fn.update(tp.intersection(masked_pos)) 
 
     # load consensus file
     pipeline_genome = load_consensus(pipeline_genome_path)

--- a/compare_snps.py
+++ b/compare_snps.py
@@ -57,6 +57,7 @@ def analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_fi
         # TPs, FPs and FNs in masked regions 
         tp = tp.difference(masked_pos)
         fp = fp.difference(masked_pos) 
+        fn += tp.intersection(masked_pos) 
 
     # load consensus file
     pipeline_genome = load_consensus(pipeline_genome_path)

--- a/compare_snps.py
+++ b/compare_snps.py
@@ -57,7 +57,7 @@ def analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_fi
         # TPs, FPs and FNs in masked regions 
         tp = tp.difference(masked_pos)
         fp = fp.difference(masked_pos) 
-        fn += tp.intersection(masked_pos) 
+        fn.update(tp.intersection(masked_pos)) 
 
     # load consensus file
     pipeline_genome = load_consensus(pipeline_genome_path)

--- a/compare_snps.py
+++ b/compare_snps.py
@@ -57,7 +57,6 @@ def analyse(simulated_snp_path, pipeline_snp_path, pipeline_genome_path, mask_fi
         # TPs, FPs and FNs in masked regions 
         tp = tp.difference(masked_pos)
         fp = fp.difference(masked_pos) 
-        fn = fn.difference(masked_pos)
 
     # load consensus file
     pipeline_genome = load_consensus(pipeline_genome_path)


### PR DESCRIPTION
This bugfix corrects how the mask is applied to error sites. 

**Prior to fix:** 

- The mask was subtracted from FN sites. 

**After fix:**

- TP sites that intersect the mask are subtracted from the TP set and appended to the FN set.  
